### PR TITLE
Bugfix and translation improvements

### DIFF
--- a/app/src/main/java/com/averi/worldscribe/Category.java
+++ b/app/src/main/java/com/averi/worldscribe/Category.java
@@ -33,6 +33,25 @@ public enum Category {
         }
     }
 
+    /* Added for the menu titles of connections, because the text was a mixed of translation and english.
+       This function is used in SelectArticleActivity@setAppBar*/
+
+    public String translatedName(Context context) {
+        switch (this) {
+            case Person:
+                return context.getResources().getString(R.string.personText);
+            case Group:
+                return context.getResources().getString(R.string.groupText);
+            case Place:
+                return context.getResources().getString(R.string.placeText);
+            case Item:
+                return context.getResources().getString(R.string.itemsText);
+            case Concept:
+            default:
+                return context.getResources().getString(R.string.conceptText);
+        }
+    }
+
     public String pluralName(Context context) {
         switch (this) {
             case Person:

--- a/app/src/main/java/com/averi/worldscribe/activities/SelectArticleActivity.java
+++ b/app/src/main/java/com/averi/worldscribe/activities/SelectArticleActivity.java
@@ -113,7 +113,7 @@ BottomBarActivity {
     @Override
     protected void setAppBar() {
         if (canChooseOneCategoryOnly) {
-            appBar.setTitle(getString(R.string.selectArticleTitle, category.name()));
+            appBar.setTitle(getString(R.string.selectArticleTitle, category.translatedName(this)));
         } else {
             appBar.setTitle(getString(R.string.selectArticleTitle, getString(R.string.article)));
         }

--- a/app/src/main/res/values-de/string.xml
+++ b/app/src/main/res/values-de/string.xml
@@ -73,12 +73,12 @@
     <string name="propertiesHint">Eigenschaften / Beschreibung</string>
     <string name="propertiesField">Eigenschaften</string>
     <string name="historyHint">Geschichte</string>
-    <string name="permissionExplanation">Die Dateien für die Welten werden auf dem externen Speicher deines Gerätes gespeichert. Um diese App verwenden zu können, müssen Sie den Schreibzugriff auf den externen Speicher zulassen.</string>
+    <string name="permissionExplanation">Die Dateien für die Welten werden auf dem externen Speicher deines Gerätes gespeichert. Um diese App verwenden zu können, muss der Schreibzugriff auf den externen Speicher zulassen werden.</string>
     <string name="permissionButtonText">Fortfahren</string>
     <string name="emptyListText">Noch keine Einträge!</string>
     <string name="nothingToLinkText">Nichts zum Verbinden!</string>
     <string name="loadWorldTitle">Welt betreten…</string>
-    <string name="worldAlreadyExistsText">Es existiert bereits eine Welt mit diesem Namen. \nBitte geben Sie einen anderen Namen ein.</string>
+    <string name="worldAlreadyExistsText">Es existiert bereits eine Welt mit diesem Namen. \nBitte gebe einen anderen Namen ein.</string>
     <string name="worldCreationErrorText">Es ist ein Fehler, während der Welt Erstellung, aufgetreten.</string>
     <string name="loadWorldText">Lade Welt</string>
     <string name="createWorldText">Erstelle Welt</string>
@@ -88,7 +88,7 @@
     <string name="membershipsText">Gruppen</string>
     <string name="residencesText">Aufenthaltsort</string>
     <string name="memberRoleText">(%1$s)</string>
-    <string name="selectArticleTitle">Wähle %1$s zum verbinden</string>
+    <string name="selectArticleTitle">%1$s zum verbinden wählen</string>
     <string name="saveEditText">SPEICHERN</string>
     <string name="collapsedSectionHeader">▲ %1$s</string>
     <string name="expandedSectionHeader">▼ %1$s</string>


### PR DESCRIPTION
I've found some bug that the title of the connections has for example the english word "group" inside, this was becaused the hard-coded name was used for the title. So I've created a translatedName method in the Categorie enum and use this to get the menutitle. I've also added some better formulations for some text.